### PR TITLE
Adjust default modules

### DIFF
--- a/build/modules.conf.in
+++ b/build/modules.conf.in
@@ -8,7 +8,7 @@ applications/mod_av
 #applications/mod_cluechoo
 applications/mod_commands
 applications/mod_conference
-#applications/mod_curl
+applications/mod_curl
 #applications/mod_cv
 applications/mod_db
 #applications/mod_directory
@@ -39,7 +39,7 @@ applications/mod_httapi
 #applications/mod_rad_auth
 #applications/mod_redis
 #applications/mod_rss
-applications/mod_signalwire
+#applications/mod_signalwire
 applications/mod_sms
 #applications/mod_sms_flowroute
 #applications/mod_snapshot
@@ -118,10 +118,10 @@ event_handlers/mod_event_socket
 #formats/mod_imagick
 formats/mod_local_stream
 formats/mod_native_file
-formats/mod_png
+#formats/mod_png
 #formats/mod_portaudio_stream
 #formats/mod_shell_stream
-#formats/mod_shout
+formats/mod_shout
 formats/mod_sndfile
 #formats/mod_ssml
 formats/mod_tone_stream
@@ -134,7 +134,7 @@ languages/mod_lua
 #languages/mod_perl
 #languages/mod_python
 #languages/mod_python3
-#languages/mod_v8
+languages/mod_v8
 #languages/mod_yaml
 loggers/mod_console
 #loggers/mod_graylog2
@@ -166,7 +166,7 @@ xml_int/mod_xml_cdr
 #xml_int/mod_xml_ldap
 #xml_int/mod_xml_radius
 xml_int/mod_xml_rpc
-xml_int/mod_xml_scgi
+#xml_int/mod_xml_scgi
 
 #mod_freetdm|https://github.com/freeswitch/freetdm.git -b master
 


### PR DESCRIPTION
- Disable SignalWire, png
- Enable curl shout v8 xml_scgi

Others might have other default prefs, but I think there is a common denominator here, comments welcome.
.